### PR TITLE
Site Services Expansion (Docs + SOPs + Data)

### DIFF
--- a/.github/ISSUE_TEMPLATE/research-competitors.yml
+++ b/.github/ISSUE_TEMPLATE/research-competitors.yml
@@ -1,0 +1,14 @@
+name: Research — Competitor Scan
+description: Identify 3 local competitors with pricing/positioning
+title: "Research: [service] competitors"
+labels: ["task","vendor","pilot"]
+body:
+  - type: input
+    id: service
+    attributes:
+      label: Service (cleanup / fencing / erosion)
+  - type: textarea
+    id: findings
+    attributes:
+      label: Notes
+      description: URLs, price signals, turnaround times

--- a/.github/ISSUE_TEMPLATE/research-suppliers.yml
+++ b/.github/ISSUE_TEMPLATE/research-suppliers.yml
@@ -1,0 +1,18 @@
+name: Research — Supplier/Vendor
+description: Find suppliers and terms for materials/equipment
+title: "Research: [supplier] for [service]"
+labels: ["task","vendor"]
+body:
+  - type: input
+    id: supplier
+    attributes:
+      label: Supplier
+  - type: input
+    id: service
+    attributes:
+      label: Service (cleanup / fencing / erosion)
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Pricing, delivery, credit terms, lead times

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Create a specialized tear-off and site preparation service staffed by individual
 - First right to invest/partner for current employer
 - Target 20–50 contractor clients
 
+### Divisions (Roadmap)
+- Roofing Support (pilot): tear-off & site prep
+- Site Prep: general cleanup, final cleans, material staging
+- Fence & Erosion: temporary fencing, silt fence, wattles, inlet protection
+
 ## Roadmap
 **Validation (current)**
 - [ ] Insurance broker consultation (rates, codes, liability)

--- a/business-plan/site-services-expansion.md
+++ b/business-plan/site-services-expansion.md
@@ -1,0 +1,38 @@
+# Site Services Expansion — 2nd Story Services
+
+## Summary
+Add three service lines that leverage the pilot’s labor + safety backbone:
+1) General Cleanup / Site Prep
+2) Temporary Fencing (panel install/remove; monthly renewals)
+3) Erosion & Stormwater Control (silt fence, wattles, inlet protection)
+
+## Why Now
+- Same workforce profile; quick-train tasks
+- Strong demand; underserved by small GCs/remodelers
+- Recurring/monthly revenue (fence rentals, erosion maintenance)
+
+## Market (Austin quick take)
+- High residential/commercial build volumes
+- GC pain point: cleanup reliability; erosion compliance
+- Fencing renewals drive predictable cash flow
+
+## Entry Costs (estimates placeholders)
+- Cleanup kit (rakes, brooms, magnets, bins): $X
+- Trailer + tie-downs: $X
+- Fence inventory lease OR partner arrangement: $X
+- Erosion materials per job (silt fence/ft, wattles, inlet): $X
+
+## Pricing Models (draft)
+- Cleanup: per visit or per project (rough/final)
+- Fence: install + monthly rental; removal fee
+- Erosion: $/linear ft + monthly inspection/maintenance
+
+## Risks & Mitigations
+- Scheduling clashes → central dispatch & route batching
+- QC variability → SOPs + photos on completion
+- Safety → OSHA-10 lead, daily checklist
+
+## Next Steps
+- Research 3 local comps for each line (pricing/lead times)
+- Add SOPs & data logs
+- Pilot a “Roofing + Cleanup” bundle with a friendly GC/roofer

--- a/data/site-services-metrics.csv
+++ b/data/site-services-metrics.csv
@@ -1,0 +1,1 @@
+week,job_id,service_type,visit_type,hours,crew_size,materials_cost,disposal_cost,photos_links,notes

--- a/data/vendor-contacts.csv
+++ b/data/vendor-contacts.csv
@@ -1,1 +1,4 @@
 name,type,contact,phone,email,notes
+2nd Story Fence Supplier,fencing,,,,,
+Erosion Materials Co.,erosion,,,,,
+Dumpster Partner,hauling/disposal,,,,,

--- a/marketing/brand-positioning.md
+++ b/marketing/brand-positioning.md
@@ -11,3 +11,10 @@ Reliable, compliant site-prep for roofers while creating meaningful employment i
 - Contractors: Free specialists; compliance edge; reliable schedule.
 - Recovery partners: Structured, dignified, growth path.
 - Homeowners: Faster, cleaner installs with community impact.
+
+## Site Services Positioning
+Clean Sites. Strong Foundations. Second Chances.
+
+- **Site Prep:** reliable cleanup and staging so crews can build
+- **Fence & Erosion:** simple compliance handled by trained techs
+- **Proof:** photo sign-off + weekly report; optional diversion receipts

--- a/operations/sop-erosion-control.md
+++ b/operations/sop-erosion-control.md
@@ -1,0 +1,19 @@
+# SOP — Erosion & Stormwater (Residential/Light Commercial)
+
+## Scope
+Silt fence, wattles, inlet protection per city/TCEQ spec.
+
+## Install
+- Orient silt fence on downhill perimeters
+- Trench ~6", fabric down-slope, backfill/tamp
+- Stake spacing per spec; overlap 6–12"
+
+## Inlet Protection
+- Wrap grate or set curb inlet barriers; maintain access
+
+## Maintenance
+- Inspect after ≥0.5" rain and weekly
+- Repair undermining/tears; log with photos
+
+## Closeout
+- Remove upon final stabilization; dispose per local rules

--- a/operations/sop-site-cleanup.md
+++ b/operations/sop-site-cleanup.md
@@ -1,0 +1,21 @@
+# SOP — Site Cleanup (Rough & Final)
+
+## Scope
+Debris removal, sweep, magnet pass, staging bins, dumpster coordination.
+
+## Prep
+- PPE; site hazards brief
+- Separate bins: debris, metal, recyclable, trash
+
+## Rough Clean
+- Bulk removal by area; keep walkways clear
+- Magnet sweep; bag small debris
+- Photos: before/after (wide + close-up)
+
+## Final Clean
+- Detail sweep; entry paths; driveway/yard
+- Verify dumpster pickup time
+- Photos: final surfaces + staging area
+
+## Handoff
+- Lead sign-off; QC note saved to job record

--- a/operations/sop-temp-fencing.md
+++ b/operations/sop-temp-fencing.md
@@ -1,0 +1,19 @@
+# SOP — Temporary Fencing (Panels)
+
+## Scope
+Panel install/remove, gates, windscreen, signage.
+
+## Install
+- Layout plan; utility check if posts used
+- Panel stands level; secure clamps; braces at corners
+- Gate section clear; signage per GC
+
+## Safety
+- Visibility at driveways/sidewalks
+- No sharp edges exposed
+
+## Photos
+- Perimeter overview; gate detail; anchor points
+
+## Removal
+- Reverse order; stack panels; verify inventory count

--- a/proposals/bundle-roofing-plus-siteprep.md
+++ b/proposals/bundle-roofing-plus-siteprep.md
@@ -1,0 +1,13 @@
+# Bundled Offering — Roofing Support + Site Prep
+
+## Scope
+- Tear-off & deck prep (roofing support)
+- Site cleanup (rough + final)
+- Optional: temporary fencing and basic erosion controls
+
+## Why Bundle
+- Single schedule/dispatch; fewer calls for GC/roofer
+- Cleaner handoff; faster installs; fewer callbacks
+
+## Pricing (placeholder)
+- Package day-rate or per-square + adders (fence, erosion)


### PR DESCRIPTION
## Summary
- Add Site Services expansion memo with market snapshot, entry costs, pricing models, risks, and next steps
- Publish SOPs for site cleanup, temporary fencing, and erosion control alongside metrics CSV and vendor placeholders
- Create bundled offering proposal stub, extend marketing positioning, and add research issue templates
- Update README with divisions roadmap covering roofing, site prep, and fence/erosion tracks

## Testing
- n/a

---
Justin: add labels vendor, service-cleanup, service-fence, service-erosion. Consider enabling branch protection on main (require PR + 1 review).

------
https://chatgpt.com/codex/tasks/task_e_68e197f9c2a8832cb6c6726491ddf132