### PR TITLE
Add wiki drafts and tracking reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 2nd Story Services
 *Elevating roofing operations, empowering second chances*
 
+[➡️ Project Wiki](https://github.com/justindbilyeu/2ndStory-Services/wiki) — overview for owners/partners
+
 ## Vision
 Create a specialized tear-off and site preparation service staffed by individuals from Austin's recovery community, solving labor inefficiency in residential roofing while providing meaningful employment and workforce reentry opportunities.
 

--- a/tracking/maintain-wiki-parity.md
+++ b/tracking/maintain-wiki-parity.md
@@ -1,0 +1,6 @@
+# Maintain Wiki parity with repo docs (monthly sweep)
+
+## Checklist
+- [ ] Update links if files move
+- [ ] Add any new SOPs/pages
+- [ ] Remove stale references

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,0 +1,5 @@
+# Changelog (Milestones)
+
+- YYYY-MM-DD — Wiki launched  
+- YYYY-MM-DD — Insurance sanity check added  
+- YYYY-MM-DD — Site Services expansion docs added  

--- a/wiki/Contacts-&-Privacy.md
+++ b/wiki/Contacts-&-Privacy.md
@@ -1,0 +1,5 @@
+# Contacts & Privacy
+
+- Keep personal contact details **inside the repo** (private), not in the wiki.
+- Working list: [`resources/contacts.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/resources/contacts.md)
+- Strip PII before sharing exports with third parties.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,15 @@
+# Getting Started (Internal)
+
+## How we work
+- Keep the repo **private** during the pilot.
+- No PII in commits; use redactions where necessary.
+- Open issues using templates (Task / Meeting Notes / Research).
+
+## Branch & PR
+- Branch names: `feat/...`, `chore/...`, `docs/...`
+- 1 PR = 1 clear change. Request review before merging.
+
+## Weekly Rhythm
+- Update `data/pilot-metrics.csv`
+- Post a weekly brief using `templates/owner-update-email.md`
+- Log validations in `/validation/` (notes + links)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,22 @@
+# 2nd Story Services — Wiki
+*Elevating roofing operations, empowering second chances*
+
+Welcome! This wiki is a high-level overview. Working docs live in the repo.
+
+## Quick Links
+- 🧭 [Project README](https://github.com/justindbilyeu/2ndStory-Services#readme)
+- ✅ [Validation Hub](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/README.md)
+- 📄 Pilot Proposal (90 Days): [`/proposals/v1-internal-pilot.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/proposals/v1-internal-pilot.md)
+- 🛡️ Insurance Sanity Check: [`/validation/insurance-sanity-check.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/insurance-sanity-check.md)
+- 🧰 SOP Index: [`/operations/README.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/README.md)
+- 📦 Data (metrics & vendors): [`/data/`](https://github.com/justindbilyeu/2ndStory-Services/tree/main/data)
+
+## Current Phase
+**Validation** — Insurance, recovery partnerships, QC baselines, disposal/recycling options.
+
+## Divisions (Roadmap)
+- Roofing Support (pilot): tear-off & site prep  
+- Site Prep: general cleanup / final cleans / staging  
+- Fence & Erosion: temp fencing, silt fence, wattles, inlet protection
+
+**Contact:** Justin Bilyeu — [add phone/email]

--- a/wiki/Insurance.md
+++ b/wiki/Insurance.md
@@ -1,0 +1,9 @@
+# Insurance (Public Texas Data)
+
+We use TDI public advisory loss costs and LCM math for planning; broker quotes optional later.
+
+- Quick reference: [`validation/insurance-sanity-check.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/insurance-sanity-check.md)
+- Scenarios CSV: [`data/comp-scenarios.csv`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/data/comp-scenarios.csv)
+- Research hub: [`validation/insurance-research.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/insurance-research.md)
+
+**Rule of thumb:** Rate per $100 payroll = Loss Cost × LCM. Start with 5551 roofing baseline.

--- a/wiki/Pilot-Playbook.md
+++ b/wiki/Pilot-Playbook.md
@@ -1,0 +1,9 @@
+# Pilot Playbook (90 Days)
+
+**Crew:** 1 OSHA-10 lead + 4–5 workers  
+**Scope:** 20–25 jobs alongside install crews  
+**Metrics:** installer hours/job, total duration, QC/safety, retention, disposal $/ton  
+**Success:** ≥20% fewer installer hours OR ≥15% more jobs/month; QC/safety ≥ baseline; ≥80% retention
+
+- Pilot brief: [`/docs in repo`](https://github.com/justindbilyeu/2ndStory-Services/tree/main/proposals)
+- Weekly template: [`/proposals/weekly-update-template.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/docs/pilot/weekly-update-template.md) *(update path if needed)*

--- a/wiki/SOP-Index.md
+++ b/wiki/SOP-Index.md
@@ -1,0 +1,7 @@
+# SOP Index
+
+- Clean Tear-Off for Recycling: [`operations/tearoff-recycling-sop.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/tearoff-recycling-sop.md)
+- Site Cleanup (Rough/Final): [`operations/sop-site-cleanup.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/sop-site-cleanup.md)
+- Temporary Fencing (Panels): [`operations/sop-temp-fencing.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/sop-temp-fencing.md)
+- Erosion & Stormwater: [`operations/sop-erosion-control.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/sop-erosion-control.md)
+- Safety Program Matrix: [`operations/safety-training-matrix.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/safety-training-matrix.md)

--- a/wiki/Site-Services-Expansion.md
+++ b/wiki/Site-Services-Expansion.md
@@ -1,0 +1,8 @@
+# Site Services Expansion
+
+Three add-on lines that leverage the pilot’s labor + safety backbone:
+1) **Site Prep** — cleanup, staging, final cleans  
+2) **Fence** — temp panels, gates, windscreens (monthly renewal option)  
+3) **Erosion** — silt fence, wattles, inlet protection (inspection/maintenance)
+
+Read the internal memo: [`business-plan/site-services-expansion.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/business-plan/site-services-expansion.md)


### PR DESCRIPTION
## Summary
- add a quick-access link in the README that points to the GitHub Wiki
- draft the requested wiki pages with links into the repo for source content
- add a tracking checklist to maintain parity between the wiki and repository docs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1bbab4ef8832cb19ab3c85ff8d6f5