### PR TITLE
docs: refresh wiki navigation and templates

### DIFF
--- a/wiki/Decision-Log.md
+++ b/wiki/Decision-Log.md
@@ -1,0 +1,9 @@
+# Decision Log
+
+| Date | Decision | Context | Rationale (1-2 bullets) | Outcome/Follow-up |
+|------|----------|---------|--------------------------|-------------------|
+| YYYY-MM-DD | Use TDI public rates for planning | Need comp estimate fast | • TX loss cost × LCM math • 5551 = 2.27 | Update when broker quotes arrive |
+| YYYY-MM-DD | Pilot roofing only (Phase 1) | Focus on core proof | • Clear pain point • Fastest path w/ employer | Revisit Site Prep / Fence / Erosion after 90 days |
+
+## Log
+- Add narrative decision entries below the table as they occur.

--- a/wiki/Expansion-Strategy.md
+++ b/wiki/Expansion-Strategy.md
@@ -1,0 +1,21 @@
+# Expansion Strategy
+
+Three add-on lines that leverage the pilot’s labor + safety backbone:
+1. **Site Prep** — cleanup, staging, final cleans
+2. **Fence** — temp panels, gates, windscreens (monthly renewal option)
+3. **Erosion** — silt fence, wattles, inlet protection (inspection/maintenance)
+
+Read the internal memo: [`business-plan/site-services-expansion.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/business-plan/site-services-expansion.md)
+
+## 6-Month Roadmap (post-pilot)
+| Month | Milestone | Proof / Gate |
+|------:|-----------|--------------|
+| 1–2 | Stabilize pilot metrics; document SOPs | ≥20% installer-hour reduction or ≥15% jobs/month |
+| 2–3 | Launch Site Prep small trials | 3 paid cleanups; on-time delivery ≥95% |
+| 3–4 | Fence install pilot via rental partner | 5 installs; zero safety incidents |
+| 4–6 | Erosion control pilot | 3 installs + 2 rain-event maintenances |
+
+## Service Line Targets (planning)
+- **Site Prep:** 30–45% GM (route batching)  
+- **Fence:** Install + monthly rental renewals; low inventory loss  
+- **Erosion:** $/LF + maintenance; compliance proof photos

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -4,8 +4,9 @@
 Welcome! This wiki is a high-level overview. Working docs live in the repo.
 
 ## Quick Links
+- 🗂️ Wiki overview: [[Owner Brief]]
 - 🧭 [Project README](https://github.com/justindbilyeu/2ndStory-Services#readme)
-- ✅ [Validation Hub](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/README.md)
+- ✅ Validation Hub docs: [`/validation/README.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/README.md)
 - 📄 Pilot Proposal (90 Days): [`/proposals/v1-internal-pilot.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/proposals/v1-internal-pilot.md)
 - 🛡️ Insurance Sanity Check: [`/validation/insurance-sanity-check.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/insurance-sanity-check.md)
 - 🧰 SOP Index: [`/operations/README.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/operations/README.md)

--- a/wiki/Meeting-Notes.md
+++ b/wiki/Meeting-Notes.md
@@ -1,0 +1,18 @@
+# Meeting Notes
+
+## Template
+**Date:** YYYY-MM-DD  
+**Attendees:** …  
+**Agenda:** …  
+**Decisions:**  
+- D1 … (log in [[Decision Log]])  
+**Action Items:**  
+- [ ] Owner — Task (due: YYYY-MM-DD)  → (create GitHub Issue)
+
+---
+
+## Log
+### YYYY-MM-DD — [Partner / Owner / Broker]
+- Notes: …
+- Decisions: …
+- Actions: …

--- a/wiki/Owner-Brief.md
+++ b/wiki/Owner-Brief.md
@@ -1,0 +1,20 @@
+# Owner Brief
+**What:** Dedicated tear-off & site-prep crews so installers focus on installation.  
+**Who:** OSHA-trained, documented workers from Austin’s recovery community.  
+**Why now:** Faster schedules, stronger compliance, real community impact.
+
+## Pilot (90 days)
+- Crew: 1 OSHA-10 lead + 4–5 workers
+- Scope: 20–25 jobs alongside install crews
+- Success: ≥20% fewer installer hours **or** ≥15% more jobs/month; QC/safety ≥ baseline; ≥80% retention
+
+## Scale Path
+- Internal: add crews → +15–20% capacity
+- External: standalone service lines (Site Prep, Fence, Erosion)
+
+## Quick Links
+- Pilot proposal (repo): [/proposals/v1-internal-pilot.md](../blob/main/proposals/v1-internal-pilot.md)
+- Insurance sanity check (repo): [/validation/insurance-sanity-check.md](../blob/main/validation/insurance-sanity-check.md)
+- SOPs index (repo): [/operations/README.md](../blob/main/operations/README.md)
+
+**Contact:** Justin Bilyeu — [phone/email]

--- a/wiki/Research-Navigator.md
+++ b/wiki/Research-Navigator.md
@@ -1,0 +1,13 @@
+# Research Navigator
+
+Use this to guide validation research; each line should end in a concrete next step.
+
+| Area | Question | Best Sources | Owner | Status | Next Step |
+|------|----------|--------------|-------|--------|-----------|
+| Insurance | Confirm 5551 rate band via TDI | TDI rate guide; loss-cost PDF | Justin | In progress | Add first numbers to repo CSV |
+| Recycling | Austin RAS options & tip fees | Processors/landfills call list | Justin | Planned | Call 3 vendors; log $/ton + contamination rules |
+
+**Pointers**
+- Insurance sanity check: [/validation/insurance-sanity-check.md](../blob/main/validation/insurance-sanity-check.md)
+- Quote CSV: [/data/comp-scenarios.csv](../blob/main/data/comp-scenarios.csv)
+- Disposal vendors: [/data/vendor-contacts.csv](../blob/main/data/vendor-contacts.csv)

--- a/wiki/Site-Services-Expansion.md
+++ b/wiki/Site-Services-Expansion.md
@@ -1,8 +1,0 @@
-# Site Services Expansion
-
-Three add-on lines that leverage the pilot’s labor + safety backbone:
-1) **Site Prep** — cleanup, staging, final cleans  
-2) **Fence** — temp panels, gates, windscreens (monthly renewal option)  
-3) **Erosion** — silt fence, wattles, inlet protection (inspection/maintenance)
-
-Read the internal memo: [`business-plan/site-services-expansion.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/business-plan/site-services-expansion.md)

--- a/wiki/Validation-Hub.md
+++ b/wiki/Validation-Hub.md
@@ -1,0 +1,18 @@
+# Validation Hub
+
+Centralize validation workstreams, point to live trackers, and keep experiments moving.
+
+## Focus Areas
+- **Insurance:** Start with the [[Insurance]] brief, then update rate math in [`/validation/insurance-sanity-check.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/insurance-sanity-check.md).
+- **Field Research:** Capture calls and site visits in the [[Research Navigator]] so every question lands on a clear next step.
+- **Pilot Ops:** Feed lessons into the [[Pilot Playbook]] and document changes in the [[Decision Log]].
+
+## Templates & Logs
+- Meetings → copy the template in [[Meeting Notes]] before each touchpoint.
+- Decisions → log key calls in [[Decision Log]] (table + narrative).
+- Experiments → archive results in [`/validation/README.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/README.md).
+
+## Quick Links
+- Pilot proposal (internal): [`/proposals/v1-internal-pilot.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/proposals/v1-internal-pilot.md)
+- Insurance sanity check: [`/validation/insurance-sanity-check.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/validation/insurance-sanity-check.md)
+- Vendor & metrics data: [`/data/`](https://github.com/justindbilyeu/2ndStory-Services/tree/main/data)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,13 @@
+## 2nd Story Services
+- [[Home]]
+- [[Owner Brief]]
+- [[Pilot Playbook]]
+- [[Validation Hub]]
+  - [[Insurance]]
+  - [[Research Navigator]]
+- [[SOP Index]]
+- [[Expansion Strategy]]
+- [[Decision Log]]
+- [[Meeting Notes]]
+- [[Changelog]]
+- [[Contacts & Privacy]]


### PR DESCRIPTION
## Summary
- add a left-hand sidebar and new Owner Brief landing page for quick orientation
- create reusable Decision Log, Meeting Notes, and Research Navigator pages and link them through the Validation Hub
- expand the Expansion Strategy page with a six-month roadmap and service line targets, and update the home page quick links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1c90734c8832c946a5608fbf8dc31