### PR TITLE
Add go-to-market pack for no-giveaway founding partner offer

### DIFF
--- a/data/commitments-log.csv
+++ b/data/commitments-log.csv
@@ -1,0 +1,1 @@
+date,company,contact,job_size_sq,rate_tier,commitment_type,next_step

--- a/data/pilot-calendar.csv
+++ b/data/pilot-calendar.csv
@@ -1,0 +1,1 @@
+job_id,date,address,roof_sq,crew_call,handoff_target,installer_company,status

--- a/gtm/call-script.md
+++ b/gtm/call-script.md
@@ -1,0 +1,29 @@
+# Founding Partner Call Script (60 Seconds)
+
+**Opening (0:00–0:15)**  
+"Hey [Name], it’s [Your Name] with 2nd Story. We’re helping top roofing crews hand off clean decks so your installers can roll right in. You have a quick minute?"
+
+**Credibility & Hook (0:15–0:30)**  
+"We’re working with installers who need day-of tear-off support that actually hits the schedule—clean deck, photos, and sign-off before lunch on a 30–35 square job. No gimmicks, just crews that show up, handle disposal, and hand you a ready roof."
+
+**Offer & Differentiators (0:30–0:45)**  
+"We’re inviting a few founding partners: milestone billing (85% at handoff, 15% after install-ready), today’s rate locked for 90 days, and you get priority AM slots as we scale."
+
+**Close (0:45–1:00)**  
+"If we can prove 90%+ on-time handoffs over the first 10 jobs, we keep booking. If not, we pause and tune together. How about we set a 20-minute working session to walk your ops lead through the checklist and penciling in your next installs?"
+
+---
+
+## Objection Handles
+
+**“We already have crews.”**  
+"Totally get it. Most partners do—the gap is consistent AM handoff with documentation. We plug in for surge capacity or when you need proof the deck’s ready before installers roll."
+
+**“I don’t want to be locked into pricing.”**  
+"No lock-in beyond the first handful of jobs. The 90-day rate hold just protects you from price creep while we prove value. You can throttle up or down anytime."
+
+**“What if you miss the window?”**  
+"We track on-time over a rolling 10-job window. If we slip below 90%, we pause together before you risk a crew sitting idle. That safeguard is in writing."
+
+**“Can you handle steep or double-layer tear-offs?”**  
+"Yes—with advance notice. We have tiered pricing for double-layer or steep-slope work so you know the adders before we schedule."

--- a/gtm/loi-lite.md
+++ b/gtm/loi-lite.md
@@ -1,0 +1,39 @@
+# Founding Partner Evaluation LOI (No Guarantee)
+
+**Parties:** 2nd Story Services ("2nd Story") and ______________________ ("Partner").
+
+**Purpose:** Outline the evaluation relationship for day-of tear-off and deck-prep services without exclusivity or future work guarantee.
+
+## Evaluation Scope
+- 2nd Story provides tear-off, decking prep, debris staging/removal, and photo documentation for Partner-designated residential roofing projects.
+- Target cadence: up to ______ jobs per week, scheduled at least 72 hours in advance.
+- Each job includes installer-lead acceptance sign-off upon clean-deck handoff.
+
+## Commercial Terms
+- Milestone billing: 85% due upon acceptance of clean-deck handoff; 15% Net-14 after Partner confirms install-ready status.
+- Pricing governed by the active Founding Partner rate card; adjustments require mutual written confirmation.
+- Partner retains today’s rate for 90 days from countersignature while in evaluation.
+
+## Performance Safeguards
+- 2nd Story commits to ≥90% on-time handoffs across any rolling 10-job window.
+- If performance drops below threshold, either party may pause scheduling and convene a tuning review before additional jobs are booked.
+
+## Term & Termination
+- Evaluation term: 90 days from countersignature unless extended in writing.
+- Either party may terminate with 7 days’ written notice; jobs already scheduled inside the notice window proceed or are mutually rescheduled.
+- No minimum volume guarantee is implied; Partner may allocate work elsewhere at any time.
+
+## Insurance & Safety
+- 2nd Story maintains required licensing, workers’ compensation, and $2M aggregate general liability coverage.
+- Crews comply with OSHA safety requirements and Partner site rules provided in advance.
+
+## Points of Contact
+- 2nd Story Ops Lead: ____________________ / ____________________
+- Partner Ops Lead: ____________________ / ____________________
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| 2nd Story Representative | | | |
+| Partner Representative | | | |

--- a/gtm/market-offer.md
+++ b/gtm/market-offer.md
@@ -1,0 +1,7 @@
+# Market Offer — Founding Partner (No Giveaways)
+
+**SLA:** Clean-deck handoff within agreed window (e.g., by 12:00pm for ~30–35 sq), photo-QC, installer-lead acceptance sign-off.  
+**Commercial:** Milestone billing 85/15 (85% at handoff acceptance; 15% Net-14 post install-ready confirmation).  
+**Rate-Lock:** Founding Partners keep today’s rate for 90 days (no discount).  
+**Priority Scheduling:** Early day-of slots/capacity reservation.  
+**Pause-and-Tune:** If <90% on-time over rolling 10 jobs, pause together and adjust before booking more.

--- a/gtm/rate-card.md
+++ b/gtm/rate-card.md
@@ -1,0 +1,15 @@
+# Rate Card (Structure)
+
+## Per-Square Tiers
+- 1-layer asphalt, walkable: $[___]/sq
+- 2-layer asphalt, walkable: $[___]/sq
+- Steep-slope adders: +[__]%
+
+## Disposal
+- Bundled tier: includes haul-off up to [__] tons/job
+- Line-item: $[__]/ton, min [__] tons
+
+## Minimums & Factors
+- Mobilization minimum: $[___]
+- After-hours/weekend factor: ×[__]
+- Exclusions: decking repairs, structural damage; T&M authorization required

--- a/ops/field-handoff-checklist.md
+++ b/ops/field-handoff-checklist.md
@@ -1,0 +1,7 @@
+# Field Handoff Checklist (Installer Acceptance)
+- Nails pulled / protrusions removed
+- Deck swept; soft metals preserved
+- Penetrations & rot flagged
+- Dumpster/final debris staged or removed
+- Photo set uploaded (front/back, eaves, valleys, penetrations)
+**Installer Lead Acceptance:** Name / Signature / Time

--- a/wiki/Go-to-Market.md
+++ b/wiki/Go-to-Market.md
@@ -1,0 +1,14 @@
+# Go-to-Market Pack (No-Giveaway Offer)
+
+## Core Assets
+- Market Offer: [`gtm/market-offer.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/gtm/market-offer.md)
+- Rate Card Structure: [`gtm/rate-card.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/gtm/rate-card.md)
+- Call Script & Objection Handles: [`gtm/call-script.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/gtm/call-script.md)
+- Evaluation LOI (No Guarantee): [`gtm/loi-lite.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/gtm/loi-lite.md)
+- Commitments Log: [`data/commitments-log.csv`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/data/commitments-log.csv)
+- Pilot Calendar: [`data/pilot-calendar.csv`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/data/pilot-calendar.csv)
+
+## 3-Step Playbook
+1. **Call:** Use the 60-second script to qualify and secure interest in the founding partner offer.
+2. **LOI:** Send the evaluation LOI for signature, confirming milestones, safeguards, and rate lock.
+3. **Schedule:** Log commitments, block the pilot calendar, and confirm handoff targets with installer leads.


### PR DESCRIPTION
## Summary
- add go-to-market market offer, rate card structure, call script, and evaluation LOI for the no-giveaway founding partner offer
- provide field handoff checklist plus commitments and pilot scheduling trackers to support execution
- publish a Go-to-Market wiki page linking to the new assets and outlining the 3-step playbook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1db7757d4832cabc15fa8c84bf903