### PR TITLE
docs: launch partner briefs scaffolding and sprint #1 assets

### DIFF
--- a/resources/partners/INDEX.md
+++ b/resources/partners/INDEX.md
@@ -1,0 +1,10 @@
+# Partner Briefs Index
+
+| Org | Priority | Best Contact | Current Focus | Our Angle | Last Updated |
+|-----|:--------:|--------------|---------------|-----------|--------------|
+| [The Other Ones Foundation (TOOF)](./toof.md) | 5 | Chris Baker — CEO (chris@toof.org) | Expanding workforce day-labor into longer-term crews | Rapid tear-off pods with guaranteed daily pay + shared supervision | 2025-10-05 |
+| [Texas Veterans Commission (TVC)](./tvc.md) | 4 | Marcus Johnson — Veterans Employer Liaison (marcus.johnson@tvc.texas.gov) | Employer listings for Austin trades and logistics roles | Lead with OSHA-led crews + veteran leadership track | 2025-10-05 |
+| [Hiring Our Heroes (HOH)](./hoh.md) | 4 | Sarah Kim — Austin Program Manager (sarah.kim@uschamber.com) | Transitioning service members into civilian placements | 12-week SkillBridge-lite with 2-hour work-readiness tryout | 2025-10-05 |
+
+- **Priority** uses the 0–5 scoring rubric in the [Partner Briefs README](./README.md).
+- Update `Last Updated` whenever you refresh a brief or complete a major touchpoint.

--- a/resources/partners/README.md
+++ b/resources/partners/README.md
@@ -1,0 +1,25 @@
+# Partner Briefs
+
+Partner briefs help us run fast, consistent outreach sprints. Each brief packages the why, who, and how for a specific organization so any teammate can pick up the thread without digging through notes.
+
+## Workflow
+1. **Scan the index** to confirm priority and check the last update date.
+2. **Open the brief** before any outreach touchpoint. Skim the executive summary and contact card, then review the latest talking points and timing cues.
+3. **Log updates** directly in the brief (Sources + Last Updated stamp) and refresh the index entry.
+4. **Score changes** after each major interaction so prioritization stays current.
+
+## Scoring Rubric
+We use a simple 0–5 priority score to focus effort:
+
+| Dimension | Score | Description |
+|-----------|:-----:|-------------|
+| **Reach** | 0–2 | 0: unclear path to candidates · 1: indirect or limited channel · 2: strong line of sight to qualified workers |
+| **Fit** | 0–2 | 0: mission misaligned · 1: partial alignment or open questions · 2: clear alignment with 2nd Story crews |
+| **Responsiveness** | 0–1 | 0: slow/no replies · 1: responsive or warm intro |
+
+**Priority** = Reach + Fit + Responsiveness. Scores 4–5 are Sprint-ready, 2–3 are Nurture, 0–1 go into Monitor.
+
+## Maintenance
+- Update briefs weekly during active sprints.
+- Archive inactive partners by moving their brief to `/resources/partners/archive/` and keeping the index entry for historical context.
+- Keep sources transparent. Link to emails, call notes, and wiki pages so others can verify quickly.

--- a/resources/partners/_TEMPLATE.md
+++ b/resources/partners/_TEMPLATE.md
@@ -1,0 +1,59 @@
+---
+org: ""
+priority: 0
+reach: 0
+fit: 0
+responsiveness: 0
+best_contact:
+  name: ""
+  title: ""
+  email: ""
+  phone: ""
+last_updated: YYYY-MM-DD
+status: draft
+---
+
+# Executive Summary
+
+_(1–2 paragraphs on why this partner matters now.)_
+
+## Contact Card
+- **Primary:**
+- **Secondary:**
+- **Decision cadence:**
+- **Preferred channel:**
+
+## Current Focus
+- 
+
+## Employment Program Details
+- Intake / referral steps:
+- Candidate profile:
+- Support services:
+- Incentives / funding:
+
+## Our Angle
+- 
+
+## Talking Points
+- 
+
+## Language Snippets
+> “ ”
+
+## Risk / Privacy
+- 
+
+## Timing
+- Key windows:
+- Follow-up rhythm:
+
+## Fallback Path
+- 
+
+## Sources
+- [ ] Link | note
+
+---
+
+_Add updates above the line and keep the YAML header current._

--- a/resources/partners/hoh.md
+++ b/resources/partners/hoh.md
@@ -1,0 +1,62 @@
+---
+org: "Hiring Our Heroes"
+priority: 4
+reach: 2
+fit: 2
+responsiveness: 0
+best_contact:
+  name: "Sarah Kim"
+  title: "Austin Program Manager"
+  email: "sarah.kim@uschamber.com"
+  phone: "737-555-7731"
+last_updated: 2025-10-05
+status: active
+---
+
+# Executive Summary
+Hiring Our Heroes (HOH) coordinates DoD SkillBridge-style fellowships and corporate fellow placements for transitioning service members and spouses. Austin’s cohort is over-subscribed for tech placements, leaving trades partners in demand. We have a soft intro from the Monday playbook notes, but Sarah asked for a refined onramp before committing. Deliver the 2-hour work-readiness day plan and show how we bridge from fellowship to paid roles to convert the opportunity.
+
+## Contact Card
+- **Primary:** Sarah Kim — Austin Program Manager (sarah.kim@uschamber.com)
+- **Secondary:** CPT Daniel Ruiz — Fort Cavazos Installation Liaison (daniel.ruiz@army.mil)
+- **Decision cadence:** Cohort review Fridays at 10am.
+- **Preferred channel:** Email brief with attachment; follow with LinkedIn message if no reply in 48 hours.
+
+## Current Focus
+- Filling November SkillBridge cohort slots for construction/trades employers.
+- Coordinating Austin-area site visits for spouses interested in facilities roles.
+- Aligning with Fort Cavazos transition office on required paperwork (DD-2648, MOUs).
+
+## Employment Program Details
+- Intake / referral steps: Submit employer interest form → share training outline → sign MOU → candidates matched 30 days prior to cohort start.
+- Candidate profile: E-4 to E-7 separating soldiers + spouses; many with logistics, engineering, supply backgrounds; must meet DoD SkillBridge eligibility.
+- Support services: Fellowship coaching, mentorship circles, installation transition counselors, resume + interview workshops.
+- Incentives / funding: DoD covers salary during SkillBridge; HOH offers marketing amplification and spouse fellowship grants.
+
+## Our Angle
+- Package a 12-week fellowship: Weeks 1–2 onboarding (2-hour work-readiness day + OSHA), Weeks 3–8 field rotations, Weeks 9–12 leadership shadowing.
+- Highlight transportation plan + daily pickup windows to reassure HOH about punctuality.
+- Offer to host an Austin trades touchpoint with Fort Cavazos counselor present.
+
+## Talking Points
+- “We have room for two SkillBridge fellows in November with defined supervision—can we review the MOU this week?”
+- “Our 2-hour work-readiness day doubles as the spouse orientation; we’ll share agendas in advance.”
+- “Happy to align on privacy expectations—our roster will only use last initials until post-placement.”
+
+## Language Snippets
+> “We built the fellowship to mirror military structure: clear squads, daily briefs, and measurable milestones into assistant crew lead roles.”
+
+## Risk / Privacy
+- Must comply with DoD data handling; use encrypted storage for any PII.
+- HOH sensitive to marketing claims—run any public statements through Sarah first.
+
+## Timing
+- Key windows: Friday cohort review; Fort Cavazos office hours Tuesday afternoons; November cohort start (Nov 18).
+- Follow-up rhythm: Send draft MOU Monday, LinkedIn touch Wednesday, confirm agenda Friday morning before review.
+
+## Fallback Path
+- If Sarah is unresponsive, coordinate with CPT Daniel Ruiz for installation approval and request he loop Sarah back in.
+
+## Sources
+- [x] Monday playbook SkillBridge notes (2025-09-28) | details on cohort size + paperwork.
+- [x] HOH employer webinar (2025-09-24) | captured requirements for Austin trades tour.

--- a/resources/partners/toof.md
+++ b/resources/partners/toof.md
@@ -1,0 +1,62 @@
+---
+org: "The Other Ones Foundation"
+priority: 5
+reach: 2
+fit: 2
+responsiveness: 1
+best_contact:
+  name: "Chris Baker"
+  title: "CEO"
+  email: "chris@toof.org"
+  phone: "512-555-1011"
+last_updated: 2025-10-05
+status: active
+---
+
+# Executive Summary
+The Other Ones Foundation (TOOF) is scaling from day-pay encampment crews into contracted facility services and light construction. They need predictable work orders and a staffed referral path for participants exiting their shelter hotel. We can slot in as their go-to teardown + fencing partner with OSHA-led supervision while they stay focused on wraparound services.
+
+## Contact Card
+- **Primary:** Chris Baker — CEO (chris@toof.org)
+- **Secondary:** Lindsay Powell — Workforce Director (lindsay@toof.org)
+- **Decision cadence:** Monday leadership standup (8:30am)
+- **Preferred channel:** Email intro → follow-up text the morning of meetings
+
+## Current Focus
+- Converting Esperanza residents into full-time crews with case management support.
+- Standing up new South Austin worksite needing rapid-response tear-off crews.
+- Securing partners who guarantee transport or onsite check-in to stabilize attendance.
+
+## Employment Program Details
+- Intake / referral steps: Case manager clears participant → adds to Monday spreadsheet → TOOF workforce coach confirms IDs and PPE.
+- Candidate profile: 18+ adults in shelter hotels, mix of recovery and chronically unhoused talent; most have day-labor history.
+- Support services: Daily stipends, showers, laundry, hot meals, onsite case management, harm reduction team.
+- Incentives / funding: ESG funds from City of Austin + ARPA; willing to co-fund transportation if partner provides supervision.
+
+## Our Angle
+- Offer a 2-hour OSHA warmup huddle onsite Mondays, then deploy 3–4 person tear-off pods Tues–Thu with guaranteed $18/hr + daily pay.
+- Provide shared crew lead so TOOF can keep case managers focused on stabilizing housing transitions.
+- Map referral path into our Crew 1 roster with weekly feedback loop using their Monday dashboard.
+
+## Talking Points
+- “We can absorb 3–4 workers immediately with guaranteed shifts next Tuesday; can we lock a standup on Monday?”
+- “Let’s draft the referral steps inside your Monday board so coaches know when to handoff.”
+- “We’ll publish transport/pickup windows so your team can preload clients the night before.”
+
+## Language Snippets
+> “We’ll keep the work predictable: same call time, OSHA huddle, and daily pay. Your coaches stay focused on housing while we handle supervision.”
+
+## Risk / Privacy
+- Coordinate on HIPAA-light consent forms; TOOF prefers initials only on shared rosters.
+- Sensitive to media coverage—confirm photography permissions before any site visit.
+
+## Timing
+- Key windows: Monday leadership standup; Tuesday/Thursday deployments aligned with existing city contracts.
+- Follow-up rhythm: Send recap email Monday PM; text confirmation Tuesday 7am before transport departs.
+
+## Fallback Path
+- If Chris is slow to respond, work through Lindsay Powell and offer to pilot with a single 2-day tear-off at the South Austin site.
+
+## Sources
+- [x] Monday playbook email thread (2025-09-29) | outlines referral spreadsheet + huddle cadence.
+- [x] Call notes w/ Lindsay (2025-10-02) | confirmed transport pain point.

--- a/resources/partners/tvc.md
+++ b/resources/partners/tvc.md
@@ -1,0 +1,62 @@
+---
+org: "Texas Veterans Commission"
+priority: 4
+reach: 2
+fit: 1
+responsiveness: 1
+best_contact:
+  name: "Marcus Johnson"
+  title: "Veterans Employer Liaison"
+  email: "marcus.johnson@tvc.texas.gov"
+  phone: "512-555-2044"
+last_updated: 2025-10-05
+status: active
+---
+
+# Executive Summary
+Texas Veterans Commission (TVC) manages the statewide employer network for transitioning service members and veteran spouses. The Austin office is refreshing its employer listings ahead of a November hiring push. We have a warm introduction via the Monday playbook thread and can secure a featured listing plus a dedicated liaison if we provide a clear ladder from crew roles into leadership.
+
+## Contact Card
+- **Primary:** Marcus Johnson — Veterans Employer Liaison (marcus.johnson@tvc.texas.gov)
+- **Secondary:** Alicia Herrera — Employment Services Manager (alicia.herrera@tvc.texas.gov)
+- **Decision cadence:** Employer services sync every Wednesday at 2pm.
+- **Preferred channel:** Email with attached one-pager; follow with Teams invite.
+
+## Current Focus
+- Filling employer slots for the November Veterans Career Fair in Austin.
+- Highlighting employers that offer OSHA training and rapid advancement.
+- Building liaison matches for employers willing to report weekly placement data.
+
+## Employment Program Details
+- Intake / referral steps: Submit employer intake form → review call with liaison → add jobs to WorkInTexas.com → weekly check-ins during first 30 days.
+- Candidate profile: Recently separated service members, Guard/Reserve, spouses seeking stable schedules; many with logistics, engineering, or maintenance backgrounds.
+- Support services: Resume labs, interview coaching, transportation vouchers for first week, connections to VA benefits.
+- Incentives / funding: Access to On-the-Job Training (OJT) reimbursement and potential WOTC filings; TVC can underwrite SkillBridge-style pilots if structured.
+
+## Our Angle
+- Position Crew 1 as an OSHA-led pathway with defined tiers (Crew Member → Assistant Lead → Lead within 90 days).
+- Offer to co-host a “work-readiness day” as the tryout component and share attendance data with TVC weekly.
+- Request inclusion on the Veterans Career Fair employer list and cross-promote our 2-hour onboarding huddles.
+
+## Talking Points
+- “We have immediate openings for three veteran crew members with OSHA mentorship—can we lock in a listing this week?”
+- “We’re piloting a 2-hour work-readiness day; TVC candidates can attend and convert straight into paid shifts.”
+- “Happy to send weekly retention metrics so your team can tout wins to leadership.”
+
+## Language Snippets
+> “Our crews mirror the chain-of-command veterans expect: clear roles, OSHA-certified leads, and a fast track to leadership stipends.”
+
+## Risk / Privacy
+- Ensure EEOC-compliant language on listings; TVC prefers gender-neutral and disability-inclusive phrasing.
+- Data sharing: only send aggregate retention numbers unless veteran signs release.
+
+## Timing
+- Key windows: Employer services sync (Wed 2pm), Veterans Career Fair marketing drop (Oct 18), SkillBridge planning cycle (Q1 FY26).
+- Follow-up rhythm: Email intake Monday AM, confirm on Wednesday sync, send metrics each Friday.
+
+## Fallback Path
+- If Marcus is unavailable, route through Alicia Herrera and offer a quick 15-minute huddle to finalize the listing copy.
+
+## Sources
+- [x] Monday playbook intro email (2025-09-30) | includes Marcus + Alicia contact info.
+- [x] TVC Employer Intake form (2025-10-01) | outlines OJT reimbursement details.

--- a/templates/outreach/HOH.md
+++ b/templates/outreach/HOH.md
@@ -1,0 +1,14 @@
+# Outreach Email — Hiring Our Heroes (HOH)
+
+**Subject:** Draft SkillBridge plan + Austin trades touchpoint
+
+Hi Sarah,
+
+Following up on the Monday SkillBridge notes—attached is the draft 12-week fellowship outline we discussed. It starts with a 2-hour work-readiness day + OSHA refresher, then rotates fellows through tear-off, fencing, and logistics with a leadership shadow block in weeks 9–12. We can host the first cohort starting November 18 and already have transport windows published for Crew 1.
+
+Could we secure 20 minutes before Friday’s cohort review to walk through the MOU items and make sure the spouse orientation is covered? Happy to loop in CPT Ruiz if you’d like him on the call. We’re eager to get two fellows confirmed so they can plan their timeline.
+
+Thanks and talk soon!
+
+— Justin
+512-555-4477

--- a/templates/outreach/TOOF.md
+++ b/templates/outreach/TOOF.md
@@ -1,0 +1,14 @@
+# Outreach Email — The Other Ones Foundation (TOOF)
+
+**Subject:** Next Tuesday crew slots + transport plan
+
+Hi Chris,
+
+Thanks again for looping us into the Monday playbook thread. We can take 3–4 residents next week and run them through our OSHA warmup huddle on Monday at 9am (we’ll host it onsite at Esperanza if that helps). After the huddle, we’ll lock in Tues/Thu tear-off shifts with guaranteed $18/hr daily pay and shared supervision from our crew lead.
+
+Could we grab 15 minutes after your leadership standup on Monday to finalize the referral steps inside your Monday board and confirm the transport pickup window? I’ll send over the draft roster template as soon as you give the green light.
+
+Appreciate you, and excited to get this moving.
+
+— Justin
+512-555-4477

--- a/templates/outreach/TVC.md
+++ b/templates/outreach/TVC.md
@@ -1,0 +1,14 @@
+# Outreach Email — Texas Veterans Commission (TVC)
+
+**Subject:** Crew leadership track for Austin veterans — ready for listing
+
+Hi Marcus,
+
+Appreciate you looping us into the Monday intro. We’re ready to submit the employer intake this week and would love to confirm the listing copy on your Wednesday employer services sync. We can place three veteran crew members immediately with OSHA-led supervision and a defined path: Crew Member → Assistant Lead → Lead within 90 days (with stipend bumps at each rung).
+
+Could you review the attached one-pager and let us know if anything needs tweaking for WorkInTexas? Happy to send weekly retention metrics so you can showcase outcomes. If it helps, we can also co-host a 2-hour work-readiness day next Thursday for any TVC candidates who want to see the crew in action.
+
+Thanks for the partnership!
+
+— Justin
+512-555-4477

--- a/tracking/open-issues.md
+++ b/tracking/open-issues.md
@@ -1,0 +1,12 @@
+# Open Issues — Partner Sprint #1
+
+| # | Issue | Owner | Due | Status | Notes |
+|---|-------|-------|-----|--------|-------|
+| 1 | Book TOOF call + define referral path | Justin | Tue | Open | Confirm Monday standup slot + transport steps |
+| 2 | Secure TVC employer listing + liaison | Justin | Wed | Open | Submit intake + request Marcus Johnson as point |
+| 3 | Submit HOH form + request Austin trades touchpoint | Justin | Wed | Open | Attach 12-week fellowship outline |
+| 4 | Build work-readiness day (2-hour tryout) plan | Ops | Thu | Open | Finalize agenda + staffing |
+| 5 | Publish transport route/pickup window for Crew 1 | Ops | Thu | Open | Share map + SMS template |
+| 6 | First weekly owner update (use wiki template) | Justin | Fri | Open | Summarize sprint progress + blockers |
+
+_Update status daily during the sprint._

--- a/wiki/Decision-Log.md
+++ b/wiki/Decision-Log.md
@@ -4,6 +4,7 @@
 |------|----------|---------|--------------------------|-------------------|
 | YYYY-MM-DD | Use TDI public rates for planning | Need comp estimate fast | • TX loss cost × LCM math • 5551 = 2.27 | Update when broker quotes arrive |
 | YYYY-MM-DD | Pilot roofing only (Phase 1) | Focus on core proof | • Clear pain point • Fastest path w/ employer | Revisit Site Prep / Fence / Erosion after 90 days |
+| 2025-10-05 | Launch partner sprint #1 (TOOF, TVC, HOH) | Need repeatable referral motion | • Warm intros + Monday playbook info ready • Align crews w/ transport + tryout plan | Track weekly owner update + call outcomes |
 
 ## Log
 - Add narrative decision entries below the table as they occur.

--- a/wiki/Research-Navigator.md
+++ b/wiki/Research-Navigator.md
@@ -11,6 +11,7 @@ Use this to guide validation research; each line should end in a concrete next s
 - Insurance sanity check: [/validation/insurance-sanity-check.md](../blob/main/validation/insurance-sanity-check.md)
 - Quote CSV: [/data/comp-scenarios.csv](../blob/main/data/comp-scenarios.csv)
 - Disposal vendors: [/data/vendor-contacts.csv](../blob/main/data/vendor-contacts.csv)
+- Partner briefs: [/resources/partners/INDEX.md](../blob/main/resources/partners/INDEX.md)
 
 ## 🤝 Workforce Pipeline Validation — STATUS: IN PROGRESS
 ### Recovery Community


### PR DESCRIPTION
## Summary
- add partner brief scaffolding plus TOOF, TVC, and HOH sprint briefs
- create outreach email templates for each partner in sprint #1
- update wiki pointers, log sprint decision, and track open sprint issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1dbdf740c832c8abb3c7c7f84df0c