### PR TITLE
Update wiki navigation and templates

### DIFF
--- a/wiki/Decision-Log.md
+++ b/wiki/Decision-Log.md
@@ -1,9 +1,9 @@
 # Decision Log
 
-| Date | Decision | Context | Rationale (1-2 bullets) | Outcome/Follow-up |
-|------|----------|---------|--------------------------|-------------------|
-| YYYY-MM-DD | Use TDI public rates for planning | Need comp estimate fast | • TX loss cost × LCM math • 5551 = 2.27 | Update when broker quotes arrive |
-| YYYY-MM-DD | Pilot roofing only (Phase 1) | Focus on core proof | • Clear pain point • Fastest path w/ employer | Revisit Site Prep / Fence / Erosion after 90 days |
+| Date | Decision | Context | Rationale (1-2 bullets) | Owner | Status / Next Review |
+|------|----------|---------|--------------------------|-------|----------------------|
+| YYYY-MM-DD | Use TDI public rates for planning | Need comp estimate fast | • TX loss cost × LCM math • 5551 = 2.27 | Justin | Update when broker quotes arrive |
+| YYYY-MM-DD | Pilot roofing only (Phase 1) | Focus on core proof | • Clear pain point • Fastest path w/ employer | Justin | Revisit Site Prep / Fence / Erosion after 90 days |
 
 ## Log
 - Add narrative decision entries below the table as they occur.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,16 @@
+# FAQ
+
+## What does 2nd Story Services provide?
+We deliver dedicated tear-off and site-prep crews so install teams can stay focused on installation and close more jobs.
+
+## How fast can a crew deploy?
+A pilot crew (lead + 4–5 workers) can mobilize inside two weeks once job cadence and safety orientation are confirmed.
+
+## How do you handle compliance and safety?
+Crews are OSHA-trained, documented, and supervised by a lead who manages daily toolbox talks, PPE checks, and post-job reporting.
+
+## What are the success metrics for the pilot?
+Target outcomes include ≥20% fewer installer hours or ≥15% more jobs per month while maintaining baseline quality, safety, and ≥80% worker retention.
+
+## Who should I contact with questions?
+Reach out to Justin Bilyeu at the listed phone/email for scheduling, pricing, or partnership questions.

--- a/wiki/Owner-Brief.md
+++ b/wiki/Owner-Brief.md
@@ -1,7 +1,12 @@
 # Owner Brief
-**What:** Dedicated tear-off & site-prep crews so installers focus on installation.  
-**Who:** OSHA-trained, documented workers from Austin’s recovery community.  
+**What:** Dedicated tear-off & site-prep crews so installers focus on installation.
+**Who:** OSHA-trained, documented workers from Austin’s recovery community.
 **Why now:** Faster schedules, stronger compliance, real community impact.
+
+## Offer
+- Crew-in-a-box covering tear-off, hauling, site prep, and day-one staging.
+- Supervisor manages toolbox talks, safety documentation, and job closeout photos.
+- Flexible engagement: deploy alongside internal crews or run as a standalone prep unit.
 
 ## Pilot (90 days)
 - Crew: 1 OSHA-10 lead + 4–5 workers

--- a/wiki/Weekly-Update-Template.md
+++ b/wiki/Weekly-Update-Template.md
@@ -1,0 +1,29 @@
+# Weekly Update Template
+
+**Week of:** YYYY-MM-DD
+**Prepared by:** Name / Role
+
+## Highlights
+- Win or milestone #1
+- Win or milestone #2
+- Customer / crew shout-outs
+
+## Metrics Snapshot
+| Metric | Target | Actual | Notes |
+|--------|--------|--------|-------|
+| Jobs completed |  |  |  |
+| Labor hours saved |  |  |  |
+| Safety / QC issues |  |  |  |
+
+## Pipeline & Scheduling
+- Upcoming jobs (dates, crews, dependencies)
+- Risks or blockers to clear
+
+## Decisions & Support Needed
+- Decision request
+- Context / data attached
+- Owner / due date
+
+## Next Steps
+- Task | Owner | Due date
+- Task | Owner | Due date

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,6 +1,8 @@
 ## 2nd Story Services
 - [[Home]]
 - [[Owner Brief]]
+- [[FAQ]]
+- [[Weekly Update Template]]
 - [[Pilot Playbook]]
 - [[Validation Hub]]
   - [[Insurance]]


### PR DESCRIPTION
## Summary
- add FAQ and weekly update template wiki pages to support pilot communications
- expand owner brief with offer details and quick links
- refresh navigation sidebar and decision log table headers for better tracking

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1dc703ec4832ca5455c859b1f5d3e