### PR TITLE
Pilot Playbook: Master Execution Checklist + SOPs (+ wiki)

### DIFF
--- a/ops/sop/Pilot-Daily-Routine.md
+++ b/ops/sop/Pilot-Daily-Routine.md
@@ -1,0 +1,12 @@
+# Pilot Daily Routine (Phase 3)
+
+This routine is mirrored from the Master Execution Checklist and should be posted at the field office so crews and support staff stay aligned.
+
+- **05:30 – Transport check-in:** confirm vehicle availability, drivers, and crew roster.
+- **06:00 – Crew muster & stretch:** safety briefing, work assignments, weather review.
+- **11:30 – Midday pulse:** crew lead submits progress photo + short form via mobile app.
+- **15:30 – Closeout walkthrough:** verify production targets, punch list, material reorder needs.
+- **17:00 – Debrief huddle:** capture safety observations, blockers, and wins; assign follow-ups.
+- **18:00 – Data sync:** upload production metrics, incidents, and attendance to dashboard.
+
+_Field support cadence: ops lead checks in with crew leads twice daily (AM + PM) for risk review; partner liaison receives daily recap email and flags external dependencies._

--- a/ops/sop/Pilot-Metrics.md
+++ b/ops/sop/Pilot-Metrics.md
@@ -1,0 +1,14 @@
+# Pilot Metrics & Weekly Synthesis (Phase 4)
+
+## Metrics to Track Daily
+- Production units completed vs. target (by crew and cumulative).
+- Rework hours logged vs. planned (<5% of total labor).
+- Safety observations logged (goal ≥ 2 per crew per day) and corrective actions closed.
+- Attendance & punctuality (on-time arrival ≥ 98%).
+- Tool / material stockouts (zero tolerance; log incident if occurs).
+
+## Weekly Synthesis
+- Compile dashboard snapshot with trend lines for production, quality, safety, and attendance.
+- Summarize top 3 wins, top 3 issues, and actions taken/required.
+- Validate vendor performance (transport, disposal, housing) and escalate gaps.
+- Update leadership brief with recommendations for next-week adjustments.

--- a/playbooks/Master-Execution-Checklist.md
+++ b/playbooks/Master-Execution-Checklist.md
@@ -1,0 +1,138 @@
+# 2nd Story Services - Master Execution Checklist
+
+This master checklist packages every deliverable required to launch, run, and close the first three pilot weeks. Owners should work phase-by-phase and update status daily in the shared tracker so that site leadership, operations, and partners stay aligned.
+
+---
+
+## Phase 1 — Pilot Mobilization (Weeks 1–2)
+
+**Objectives**
+- Confirm scope, crew composition, and partner commitments.
+- Lock logistics (transport, tools, materials, housing) with written confirmations.
+- Publish pilot communication plan and kickoff schedule.
+
+**Checklist**
+- [ ] Finalize pilot charter (objectives, constraints, success definition) and circulate for sign-off.
+- [ ] Confirm participant roster, onboarding dates, and HR compliance steps.
+- [ ] Secure vendor agreements (transport, lodging, disposal/dumpster, meals) and upload to repo contracts folder.
+- [ ] Schedule toolbox talk template review + incident process walkthrough with field leads.
+- [ ] Draft daily field handoff checklist and print copies for week 1 crews.
+- [ ] Publish kickoff agenda + invite list (ops, field, partners) with prep notes.
+
+**Metrics Touchpoints**
+- Baseline crew readiness survey response rate ≥ 90%.
+- Kickoff attendance target ≥ 95% of roster.
+
+**Contingency Actions**
+- If vendor unavailable, escalate to procurement list within 24 hours and document alternative plan.
+- If compliance requirements slip, assign dedicated owner and update status board twice daily.
+
+---
+
+## Phase 2 — Crew & Site Readiness (Weeks 2–3)
+
+**Objectives**
+- Stage the pilot site, materials, and safety systems.
+- Train crew leads on reporting, communication, and escalation paths.
+
+**Checklist**
+- [ ] Conduct site walk with safety + ops, documenting hazards and mitigation steps.
+- [ ] Verify tool inventory (qty, condition) and stage replacements.
+- [ ] Confirm transport routes, pickup windows, and contingency driver list.
+- [ ] Run safety drill + incident escalation simulation with crew leads.
+- [ ] Post daily communication cascade (morning huddle → midday update → evening recap).
+- [ ] Upload updated site map, hazard log, and emergency contacts to wiki.
+
+**Metrics Touchpoints**
+- Site readiness checklist completion ≥ 95%.
+- Safety drill participation rate 100% of crew leads.
+
+**Contingency Actions**
+- If hazard mitigation incomplete, flag in daily standup and assign closure owner by end of day.
+- If tool inventory below minimums, trigger procurement order and note ETA in tracker.
+
+---
+
+## Phase 3 — Live Pilot Operations (Weeks 3–6)
+
+**Objectives**
+- Execute daily work plan while capturing data and feedback.
+- Maintain tight feedback loop between field, ops, and partners.
+
+### Daily Routine
+- 05:30 – Transport check-in: confirm vehicle availability, drivers, and crew roster.
+- 06:00 – Crew muster & stretch: safety briefing, work assignments, weather review.
+- 11:30 – Midday pulse: crew lead submits progress photo + short form via mobile app.
+- 15:30 – Closeout walkthrough: verify production targets, punch list, material reorder needs.
+- 17:00 – Debrief huddle: capture safety observations, blockers, and wins; assign follow-ups.
+- 18:00 – Data sync: upload production metrics, incidents, and attendance to dashboard.
+
+### Field Support Cadence
+- Ops lead checks in with crew leads twice daily (AM + PM) for risk review.
+- Partner liaison receives daily recap email and flags external dependencies.
+
+### Contingency Actions
+- Missed production targets: trigger root cause review within 12 hours and log corrective actions.
+- Safety incident: execute incident process checklist, notify leadership within 30 minutes, file report in repo.
+- Weather disruption: activate alternate indoor tasks or reschedule using contingency calendar.
+
+---
+
+## Phase 4 — Performance Measurement & Iteration (Weeks 4–8)
+
+**Objectives**
+- Track performance, quality, and safety metrics to inform adjustments.
+- Run weekly synthesis to prioritize improvements for subsequent weeks.
+
+### Metrics to Track Daily
+- Production units completed vs. target (by crew and cumulative).
+- Rework hours logged vs. planned (<5% of total labor).
+- Safety observations logged (goal ≥ 2 per crew per day) and corrective actions closed.
+- Attendance & punctuality (on-time arrival ≥ 98%).
+- Tool / material stockouts (zero tolerance; log incident if occurs).
+
+### Weekly Synthesis
+- Compile dashboard snapshot with trend lines for production, quality, safety, and attendance.
+- Summarize top 3 wins, top 3 issues, and actions taken/required.
+- Validate vendor performance (transport, disposal, housing) and escalate gaps.
+- Update leadership brief with recommendations for next-week adjustments.
+
+### Contingency Actions
+- If any metric misses threshold 2 consecutive days, convene rapid response huddle and assign owner.
+- If vendor SLA breach occurs, engage backup vendor and document in contingency tracker.
+
+---
+
+## Phase 5 — Closeout & Scale Readiness (Weeks 8–12)
+
+**Objectives**
+- Capture lessons learned, finalize documentation, and prepare for scale.
+- Validate readiness to transition from pilot to steady-state operations.
+
+**Checklist**
+- [ ] Conduct final site inspection and close punch list items.
+- [ ] Archive daily logs, safety reports, and dashboards in structured folders.
+- [ ] Facilitate retrospective workshop (field, ops, partners) with action register.
+- [ ] Update SOPs based on pilot learnings and publish revisions.
+- [ ] Deliver final report to leadership with metrics summary, ROI analysis, and recommendations.
+
+### Final Checkpoint
+- Confirm all corrective actions closed with owners + completion dates.
+- Ensure wiki + repo documentation reflects final SOPs and checklists.
+- Obtain leadership go/no-go decision for next market expansion.
+
+---
+
+## Repo & Wiki Updates (All Phases)
+- Sync new or revised SOPs to `ops/sop/` and mirror links in `wiki/`.
+- Tag updates with date + owner in commit messages for traceability.
+- Maintain change log noting which crews received updated procedures.
+
+## Contingency Plans Summary
+- Maintain centralized contingency tracker listing trigger, owner, and backup plan for logistics, staffing, and safety events.
+- Review contingency status during weekly synthesis; escalate unresolved risks to leadership.
+
+## Reporting & Communication
+- Daily: update dashboard, circulate recap email, and log issues in tracker.
+- Weekly: host pilot steering check-in, review metrics, and align on adjustments.
+- Monthly: compile executive summary covering performance, financials, and readiness to scale.

--- a/tracking/issues-pilot-prep.md
+++ b/tracking/issues-pilot-prep.md
@@ -1,0 +1,10 @@
+# Pilot Prep Issues (Label: pilot-prep)
+
+| # | Issue | Owner | Due | Status | Notes |
+|---|-------|-------|-----|--------|-------|
+| 1 | Stand up Pilot Playbook docs | Ops | 2025-10-12 | Open | Finalize checklist + SOP links, update wiki. |
+| 2 | Schedule toolbox talk template & incident process review | Safety Lead | 2025-10-14 | Open | Align with Phase 1 readiness cadence. |
+| 3 | Line up disposal/dumpster vendor | Procurement | 2025-10-09 | Open | Confirm contract + contingency provider. |
+| 4 | Print field handoff checklists | Field Ops | 2025-10-07 | Open | Use Phase 1 draft; deliver to site office. |
+
+_Track progress alongside the Master Execution Checklist to ensure readiness for pilot launch._

--- a/tracking/milestones.md
+++ b/tracking/milestones.md
@@ -1,0 +1,5 @@
+# Milestones
+
+| Milestone | Owner | Due Date | Notes |
+|-----------|-------|----------|-------|
+| Pilot Prep (30 days) | Ops Lead | 2025-11-04 | Aligns Master Execution Checklist, SOP rollout, and partner readiness. |

--- a/wiki/Pilot-Playbook.md
+++ b/wiki/Pilot-Playbook.md
@@ -1,9 +1,7 @@
-# Pilot Playbook (90 Days)
+# Pilot Playbook
 
-**Crew:** 1 OSHA-10 lead + 4–5 workers  
-**Scope:** 20–25 jobs alongside install crews  
-**Metrics:** installer hours/job, total duration, QC/safety, retention, disposal $/ton  
-**Success:** ≥20% fewer installer hours OR ≥15% more jobs/month; QC/safety ≥ baseline; ≥80% retention
+Resources for launching and operating the pilot:
 
-- Pilot brief: [`/docs in repo`](https://github.com/justindbilyeu/2ndStory-Services/tree/main/proposals)
-- Weekly template: [`/proposals/weekly-update-template.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/docs/pilot/weekly-update-template.md) *(update path if needed)*
+- [Master Execution Checklist](../playbooks/Master-Execution-Checklist.md)
+- [Pilot Daily Routine](../ops/sop/Pilot-Daily-Routine.md)
+- [Pilot Metrics & Weekly Synthesis](../ops/sop/Pilot-Metrics.md)


### PR DESCRIPTION
## Summary
- add Master Execution Checklist playbook with phases, contingency actions, repo/wiki updates, and reporting cadence
- publish dedicated SOPs for the pilot daily routine and metrics/weekly synthesis, linked from the wiki
- log the Pilot Prep (30 days) milestone and pilot-prep labeled issues for launch readiness tracking

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1e004bd10832c86bec160ff6032e4