### PR TITLE
Partner Intelligence (2025-10-04): rankings, profiles, risks, timing

### DIFF
--- a/resources/partners/INDEX.md
+++ b/resources/partners/INDEX.md
@@ -1,10 +1,16 @@
 # Partner Briefs Index
 
-| Org | Priority | Best Contact | Current Focus | Our Angle | Last Updated |
-|-----|:--------:|--------------|---------------|-----------|--------------|
-| [The Other Ones Foundation (TOOF)](./toof.md) | 5 | Chris Baker — CEO (chris@toof.org) | Expanding workforce day-labor into longer-term crews | Rapid tear-off pods with guaranteed daily pay + shared supervision | 2025-10-05 |
-| [Texas Veterans Commission (TVC)](./tvc.md) | 4 | Marcus Johnson — Veterans Employer Liaison (marcus.johnson@tvc.texas.gov) | Employer listings for Austin trades and logistics roles | Lead with OSHA-led crews + veteran leadership track | 2025-10-05 |
-| [Hiring Our Heroes (HOH)](./hoh.md) | 4 | Sarah Kim — Austin Program Manager (sarah.kim@uschamber.com) | Transitioning service members into civilian placements | 12-week SkillBridge-lite with 2-hour work-readiness tryout | 2025-10-05 |
+| Org | Priority | Contact | Our Angle | Last Updated |
+|-----|:--------:|---------|-----------|--------------|
+| [The Other Ones Foundation (TOOF)](./toof.md) | 5 | Chris Baker (CEO) | OSHA-led tear-off pod with shared crew lead | 2025-10-05 |
+| [Texas Veterans Commission (TVC)](./tvc.md) | 4 | Marcus Johnson (Vet Liaison) | Veteran ladder: crew → assistant lead → lead | 2025-10-05 |
+| [Hiring Our Heroes (HOH)](./hoh.md) | 4 | Sarah Kim (Program Manager) | 12-week SkillBridge-lite with spouse orientation | 2025-10-05 |
+| [SAFE Alliance](./Partner-Intelligence-2025-10-04.md#safe-alliance) | 3 | Andrea Torres (Econ Empowerment) | Trauma-informed crews with transport + female leads | 2025-10-04 |
+| [Dress for Success Austin](./Partner-Intelligence-2025-10-04.md#dress-for-success-austin) | 3 | Maria Lopez (Programs) | Co-branded OSHA warmup as work-readiness workshop | 2025-10-04 |
+| [Combined Arms](./Partner-Intelligence-2025-10-04.md#combined-arms) | 3 | David Nguyen (Navigator) | Syndicate listings + share weekly placement metrics | 2025-10-04 |
+| [Salvation Army Austin](./Partner-Intelligence-2025-10-04.md#salvation-army-austin) | 2 | Capt. Lisa Ramirez (Social Services) | Shuttle-supported 2-day pilot crews | 2025-10-04 |
+| [SafePlace Austin](./Partner-Intelligence-2025-10-04.md#safeplace-austin) | 2 | Jenna Patel (Employment Advocate) | Anonymized roster + closed-site assignments | 2025-10-04 |
+| [Austin Recovery](./Partner-Intelligence-2025-10-04.md#austin-recovery) | 2 | Patrick O’Neal (Partnerships) | Structured shifts with relapse protocol alignment | 2025-10-04 |
 
 - **Priority** uses the 0–5 scoring rubric in the [Partner Briefs README](./README.md).
-- Update `Last Updated` whenever you refresh a brief or complete a major touchpoint.
+- Use the [Partner Intelligence pack](./Partner-Intelligence-2025-10-04.md) for current rankings, language, risks, and timing windows.

--- a/resources/partners/Partner-Intelligence-2025-10-04.md
+++ b/resources/partners/Partner-Intelligence-2025-10-04.md
@@ -1,0 +1,118 @@
+# Partner Intelligence Summary - 2nd Story Services
+
+## Priority Rankings
+| Rank | Organization | Priority (0-5) | Quick Fit Signal | Primary Contact | Immediate Next Action |
+|-----:|--------------|----------------|------------------|-----------------|-----------------------|
+| 1 | The Other Ones Foundation (TOOF) | 5 | Ready crews + aligned supervision cadence | Chris Baker — CEO | Lock Monday standup to slot 3–4 workers into tear-off pod next week |
+| 2 | Texas Veterans Commission (TVC) | 4 | Veteran pipeline with SkillBridge/OJT funding | Marcus Johnson — Veterans Employer Liaison | Submit employer intake + request featured listing before Wed sync |
+| 3 | Hiring Our Heroes (HOH) | 4 | SkillBridge fellows + spouse cohort needing trades partners | Sarah Kim — Austin Program Manager | Deliver 12-week fellowship outline ahead of Friday cohort review |
+| 4 | SAFE Alliance | 3 | Trauma-informed women’s housing programs with job-readiness track | Andrea Torres — Director of Economic Empowerment | Share trauma-informed supervision plan + request referral pilot |
+| 5 | Dress for Success Austin | 3 | Career readiness workshops + alumni needing shift-based work | Maria Lopez — Programs Manager | Co-design co-branded work-readiness day for November calendar |
+| 6 | Combined Arms | 3 | Statewide veteran network + transition case managers | David Nguyen — Workforce Navigator | Offer to syndicate job postings via Combined Arms hub |
+| 7 | Salvation Army Austin | 2 | Shelter residents seeking rapid income + case management | Captain Lisa Ramirez — Social Services Director | Align on transport/pickup logistics for 2-day trial crew |
+| 8 | SafePlace Austin | 2 | Emergency shelter with strict privacy requirements | Jenna Patel — Employment Advocate | Provide anonymized onboarding checklist + confirm confidentiality terms |
+| 9 | Austin Recovery | 2 | Recovery housing with graduates needing structured work | Patrick O’Neal — Community Partnerships Lead | Schedule post-graduation info session for next cohort |
+
+## Immediate Action Targets
+- **Book Monday 8:30am standup with TOOF** to finalize the three-person tear-off pod and coordinate transport confirmations.
+- **Send TVC employer intake packet by Tuesday 10am** so Marcus can elevate our listing during the Wednesday employer services sync.
+- **Email HOH fellowship outline and agenda by Thursday EOD** to get on the Friday cohort review docket; include transportation and privacy addendum.
+- **Draft trauma-informed supervision one-pager for SAFE Alliance** and request a 30-minute intake call the week of October 14.
+
+## Organization Profiles
+### The Other Ones Foundation (TOOF)
+- **What they need:** Predictable shift blocks and shared crew leads so case managers can stay focused on housing transitions.
+- **Why we fit:** Our OSHA-led tear-off pods mirror their existing cadence and guarantee daily pay, easing their attendance risk.
+- **Last touch:** 2025-10-05 recap email; awaiting confirmation for Monday leadership standup.
+- **Open items:** Provide transport roster template; confirm photo permissions for site documentation.
+
+### Texas Veterans Commission (TVC)
+- **What they need:** Employers who can report weekly retention metrics and outline advancement ladders for veteran candidates.
+- **Why we fit:** Crew 1 offers tiered leadership tracks with OSHA mentorship plus data sharing for their reporting cadence.
+- **Last touch:** Intake form partially drafted 2025-10-04; Marcus requested finalized job descriptions.
+- **Open items:** Finish intake form, prepare Veterans Career Fair blurb, align on OJT reimbursement paperwork.
+
+### Hiring Our Heroes (HOH)
+- **What they need:** Clear SkillBridge fellowship structure and spouse-inclusive orientation.
+- **Why we fit:** Our 12-week fellowship template integrates onboarding, field rotations, and leadership shadowing.
+- **Last touch:** Follow-up email 2025-10-03; Sarah asked for agenda before Friday review.
+- **Open items:** Deliver fellowship outline, attach MOU draft, highlight encrypted data handling for PII.
+
+### SAFE Alliance
+- **What they need:** Trauma-informed supervisors, privacy-safe data sharing, and transportation assurances for clients exiting shelter programs.
+- **Why we fit:** We can bundle transportation support with daily check-ins and provide female-led supervision pods.
+- **Last touch:** Intro call 2025-10-02 with Andrea Torres; waiting on supervision plan draft.
+- **Open items:** Finalize confidentiality agreements, confirm PPE sizing options, identify two pilot shifts in North Austin.
+
+### Dress for Success Austin
+- **What they need:** Employers willing to co-host work-readiness workshops and provide immediate shift opportunities.
+- **Why we fit:** Our 2-hour OSHA warmup doubles as a workshop, and we can reserve crew spots for recent graduates.
+- **Last touch:** Email exchange 2025-10-01 with Maria Lopez about November programming calendar.
+- **Open items:** Submit workshop agenda, confirm co-branding guidelines, lock tentative date (target Nov 7).
+
+### Combined Arms
+- **What they need:** Consistent employers to populate the Combined Arms job hub and share success metrics.
+- **Why we fit:** We can syndicate roles statewide and plug into their case manager referral network.
+- **Last touch:** Slack DM via veterans channel 2025-10-03; David asked for three sample job posts.
+- **Open items:** Draft job posts, clarify referral feedback loop, explore webinar slot for November.
+
+### Salvation Army Austin
+- **What they need:** Rapid income pathways with transportation and predictable supervision for shelter residents.
+- **Why we fit:** Our shared crew lead plus shuttle plan reduces no-show risk and aligns with their case management rhythm.
+- **Last touch:** In-person conversation 2025-10-02 after community meeting; Captain Ramirez open to trial.
+- **Open items:** Provide shuttle schedule, confirm stipend handling, align on sobriety check expectations.
+
+### SafePlace Austin
+- **What they need:** Strict privacy assurances and female-led teams for survivors in emergency shelter.
+- **Why we fit:** We can anonymize rosters, designate female crew leads, and schedule closed-site work to protect clients.
+- **Last touch:** Referral email 2025-10-01; Jenna requested written confidentiality commitments.
+- **Open items:** Draft confidentiality statement, outline background check process, identify low-travel assignments.
+
+### Austin Recovery
+- **What they need:** Structured work placements for graduates transitioning back into the workforce.
+- **Why we fit:** Our crews offer predictable shifts, peer mentorship, and compatibility with recovery schedules.
+- **Last touch:** Phone call 2025-09-30 with Patrick O’Neal exploring November cohort engagement.
+- **Open items:** Schedule info session, share supervisor bios, coordinate with counseling team on relapse protocol.
+
+## Language to Mirror
+- “OSHA-led huddles with guaranteed daily pay and transportation built in.”
+- “Trauma-informed supervision with anonymized rosters until clients opt-in.”
+- “Tiered advancement ladder: crew member → assistant lead → lead within 90 days.”
+- “Weekly retention metrics packaged for your leadership updates.”
+
+## Risk & Privacy Watchouts
+- Use initials only on shared rosters for TOOF, SAFE Alliance, and SafePlace until releases are signed.
+- Store HOH and TVC candidate data in encrypted folders; avoid sending PII over email without password protection.
+- Confirm photo/press permissions before documenting onsite activity with TOOF or Salvation Army crews.
+- Align sobriety and relapse protocols with Austin Recovery and Salvation Army before onboarding participants.
+
+## Timing Windows
+| Window | Partners | Notes |
+|--------|----------|-------|
+| Mondays 8:30am | TOOF leadership standup | Secure weekly slot for crew assignments and transport check |
+| Wednesdays 2:00pm | TVC employer services sync | Submit materials by Tuesday morning to make the agenda |
+| Fridays 10:00am | HOH cohort review | Deliver fellowship artifacts by Thursday EOD |
+| Oct 14–18 | SAFE Alliance, Dress for Success | Ideal window for supervision plan review + workshop scheduling |
+| Nov 7 | Dress for Success (target) | Hold co-branded work-readiness session |
+| Nov 18 | HOH SkillBridge cohort start | All onboarding paperwork must be signed |
+
+## Quick Decision Guide
+| Situation | Recommended Move | Backup Plan |
+|-----------|------------------|-------------|
+| Need immediate crews for municipal tear-off | Confirm TOOF pod availability → deploy within 72 hours | Tap Salvation Army for 2-day pilot while TOOF ramps |
+| Veteran candidates ready but paperwork slow | Route through TVC OJT path | Engage Combined Arms for interim referrals |
+| Survivor referrals require privacy assurances | Lead with SAFE Alliance template + anonymized roster | Utilize SafePlace protocol for closed-site projects |
+| Workshop slot opens with little notice | Activate Dress for Success partnership | Offer HOH spouse orientation as alternative |
+
+## Follow-up Tracking
+| Partner | Owner | Next Touchpoint | Status |
+|---------|-------|-----------------|--------|
+| TOOF | Justin | 2025-10-07 (confirm crew roster) | Pending confirmation |
+| TVC | Justin | 2025-10-08 (Wed sync follow-up) | Intake in progress |
+| HOH | Justin | 2025-10-11 (post-cohort review debrief) | Materials drafting |
+| SAFE Alliance | Justin | 2025-10-14 (supervision plan review) | Scheduling |
+| Dress for Success | Justin | 2025-10-09 (agenda co-draft) | Waiting on availability |
+| Combined Arms | Justin | 2025-10-10 (job post share) | Drafting |
+| Salvation Army | Justin | 2025-10-09 (transport plan send) | Logistics outline |
+| SafePlace | Justin | 2025-10-08 (confidentiality sign-off) | Drafting |
+| Austin Recovery | Justin | 2025-10-12 (info session scheduling) | Pending |

--- a/resources/partners/priority-table.csv
+++ b/resources/partners/priority-table.csv
@@ -1,0 +1,10 @@
+rank,organization,priority,key_contact,best_for,action,notes
+1,The Other Ones Foundation (TOOF),5,"Chris Baker — CEO","Rapid tear-off crews with daily pay","Book Monday standup to lock crew roster","Need transport roster + photo permissions"
+2,Texas Veterans Commission (TVC),4,"Marcus Johnson — Veterans Employer Liaison","Veteran placements with OJT funding","Submit employer intake + request featured listing","Finalize job descriptions + OJT paperwork"
+3,Hiring Our Heroes (HOH),4,"Sarah Kim — Austin Program Manager","SkillBridge fellows + spouse orientation","Send 12-week fellowship outline before Friday review","Attach MOU draft and privacy addendum"
+4,SAFE Alliance,3,"Andrea Torres — Director of Economic Empowerment","Trauma-informed women’s program referrals","Deliver supervision plan + request pilot intake","Confirm confidentiality + PPE sizing"
+5,Dress for Success Austin,3,"Maria Lopez — Programs Manager","Work-readiness workshops feeding shifts","Co-design November work-readiness day","Align on co-branding + target Nov 7"
+6,Combined Arms,3,"David Nguyen — Workforce Navigator","Statewide veteran referral hub","Syndicate job posts via Combined Arms platform","Provide three sample postings + metrics plan"
+7,Salvation Army Austin,2,"Captain Lisa Ramirez — Social Services Director","Shelter residents needing rapid income","Align transport/pickup for 2-day pilot crew","Confirm stipends + sobriety protocol"
+8,SafePlace Austin,2,"Jenna Patel — Employment Advocate","Emergency shelter survivors","Share anonymized onboarding checklist","Deliver confidentiality statement + low-travel tasks"
+9,Austin Recovery,2,"Patrick O’Neal — Community Partnerships Lead","Recovery program graduates","Schedule post-graduation info session","Coordinate relapse protocol with counseling team"

--- a/wiki/Research-Navigator.md
+++ b/wiki/Research-Navigator.md
@@ -12,6 +12,7 @@ Use this to guide validation research; each line should end in a concrete next s
 - Quote CSV: [/data/comp-scenarios.csv](../blob/main/data/comp-scenarios.csv)
 - Disposal vendors: [/data/vendor-contacts.csv](../blob/main/data/vendor-contacts.csv)
 - Partner briefs: [/resources/partners/INDEX.md](../blob/main/resources/partners/INDEX.md)
+- Partner intelligence pack: [/resources/partners/Partner-Intelligence-2025-10-04.md](../blob/main/resources/partners/Partner-Intelligence-2025-10-04.md)
 - Talent pipelines reference: [/resources/talent-pipelines.md](../blob/main/resources/talent-pipelines.md)
 
 ## 🤝 Workforce Pipeline Validation — STATUS: IN PROGRESS
@@ -29,3 +30,7 @@ Use this to guide validation research; each line should end in a concrete next s
 - Contacts: SAFE Alliance, SafePlace Austin, Dress for Success Austin
 - Key Questions: privacy requirements, childcare coordination, PPE fit needs
 - Next Steps: Align on trauma-informed supervision plan; confirm referral process; target 1–2 pilot candidates
+
+## Partner Intelligence
+- Rankings + action plan: [/resources/partners/Partner-Intelligence-2025-10-04.md](../blob/main/resources/partners/Partner-Intelligence-2025-10-04.md)
+- Quick lookup table: [/resources/partners/INDEX.md](../blob/main/resources/partners/INDEX.md)


### PR DESCRIPTION
## Summary
- add a 2025-10-04 partner intelligence pack covering rankings, org profiles, language to mirror, risks, timing, and follow-up tracking
- seed a priority-table CSV aligned to the new rankings and link the compact partner index to detailed sections
- surface the new intel resources from the Research Navigator wiki page

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1e01c7b04832c821866a71d3a89f6