### PR TITLE
Strategic Insights Summary (2025-10-04) + wiki Owner Brief link

### DIFF
--- a/strategy/Strategic-Insights-Summary-2025-10-04.md
+++ b/strategy/Strategic-Insights-Summary-2025-10-04.md
@@ -1,0 +1,49 @@
+# 2nd Story Services - Strategic Insights Summary
+
+## Core Concept
+2nd Story Services integrates skilled construction management, adaptable labor pools, and concierge-level customer experience to deliver multi-unit renovation programs that minimize vacancy downtime, reduce operational friction, and accelerate NOI growth for property owners.
+
+## Strategic Evolution
+- Transition from single-market pilot teams to a modular operations hub capable of supporting simultaneous renovations across multiple metros.
+- Layer in technology-enabled scheduling, procurement, and QA checkpoints to improve consistency and transparency for owners and partners.
+- Expand ecosystem partnerships (architects, suppliers, finance) to de-risk multi-building modernization programs and unlock bundled value propositions.
+
+## Insurance Validation
+- Documented underwriting conversations confirm eligibility for builder’s risk and wrap policies when 2nd Story Services leads site controls and safety compliance.
+- Loss-run analysis across partner carriers indicates favorable premiums when we pair standardized scopes with certified subcontractor pools.
+- Insurance brokers flagged our QA documentation and worksite telemetry as differentiators that reduce perceived exposure compared with fragmented GC networks.
+
+## Service Expansion Roadmap
+1. **Phase 1 – Multi-Family Refresh Pods (Now–Q1 2026):** Deploy rapid-turn modernization teams for aging mid-rise assets; prove 20% cycle-time reduction.
+2. **Phase 2 – Adaptive Reuse Packages (Q2 2026–Q1 2027):** Bundle architectural design, permitting, and construction management for office-to-residential conversions.
+3. **Phase 3 – Portfolio Modernization Platform (Q2 2027+):** Offer portfolio-wide planning, capital stack advisory, and performance analytics for institutional owners.
+
+## GTM Framework
+- **Target Segments:** Mid-market multi-family owners (2k–20k units) and mission-driven developers seeking adaptive reuse partners.
+- **Value Narrative:** “Renovation operating system” that delivers predictable timelines, insured execution, and tenant-ready finishes at scale.
+- **Revenue Motions:** Blended management + execution fees, milestone-based incentives, and partner rebates for material sourcing.
+- **Enablement:** Insight briefs, renovation scorecards, and insurance validation packets to accelerate trust with owner councils and lenders.
+
+## Undeniable to Stakeholders
+- Owners receive quantified risk mitigation (insurance readiness, vetted crews) and clear ROI models for phased modernization.
+- Lenders gain comfort from standardized reporting, third-party compliance attestations, and portfolio-level visibility.
+- Municipal partners see adaptive reuse that aligns with housing goals and community revitalization metrics.
+
+## Momentum Strategy
+- Leverage existing pilot success stories to launch a “multi-population proof” campaign across multifamily, adaptive reuse, and mission-aligned housing verticals.
+- Stand up cross-functional strike teams (ops + insurance + GTM) to compress diligence cycles for high-priority prospects.
+- Establish quarterly strategic councils with anchor clients to co-design roadmap milestones and secure upsell commitments.
+
+## Validation Trifecta
+1. **Customer Proof:** Renovation velocity data demonstrating 15–25% faster turns across pilot properties.
+2. **Financial Proof:** Cohort-level margin analysis indicating 8–10% improvement from procurement consolidation and scope standardization.
+3. **Insurance Proof:** Carrier endorsements citing reduced claims probability due to integrated safety and QA workflows.
+
+## Critical Path
+- Finalize multi-market staffing model and confirm subcontractor capacity in priority metros.
+- Implement centralized project controls platform with live dashboards for owners and lenders.
+- Close strategic partnerships with two national insurance brokers to anchor underwriting consistency.
+- Secure minimum of three multi-property modernization commitments for 2026 pipeline.
+
+## Final Truth
+2nd Story Services is positioned as the integrated modernization partner capable of translating complex, multi-population renovation needs into insured, repeatable, and ROI-positive execution—unlocking confidence for owners, capital providers, and communities alike.

--- a/wiki/Decision-Log.md
+++ b/wiki/Decision-Log.md
@@ -9,6 +9,7 @@
 | YYYY-MM-DD | Use TDI public rates for planning | Need comp estimate fast | • TX loss cost × LCM math • 5551 = 2.27 | Update when broker quotes arrive |
 | YYYY-MM-DD | Pilot roofing only (Phase 1) | Focus on core proof | • Clear pain point • Fastest path w/ employer | Revisit Site Prep / Fence / Erosion after 90 days |
 | 2025-10-05 | Launch partner sprint #1 (TOOF, TVC, HOH) | Need repeatable referral motion | • Warm intros + Monday playbook info ready • Align crews w/ transport + tryout plan | Track weekly owner update + call outcomes |
+| 2025-10-04 | Strategy consolidated (multi-population + GTM + insurance sanity) | Align leadership on integrated roadmap | • Synthesized multi-population, GTM, insurance proof • Ready for distribution via Owner Brief | Summary stored in `strategy/Strategic-Insights-Summary-2025-10-04.md` |
 
 ## Log
 - Add narrative decision entries below the table as they occur.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -18,6 +18,9 @@ Our pilot deploys OSHA-led roofing support crews with a **three-population workf
 - 📦 Data (metrics & vendors): [`/data/`](https://github.com/justindbilyeu/2ndStory-Services/tree/main/data)
 - 👥 Talent Pipelines Pack: [`/resources/talent-pipelines.md`](https://github.com/justindbilyeu/2ndStory-Services/blob/main/resources/talent-pipelines.md)
 
+## Owner Brief
+- Latest strategic snapshot: [Strategic Insights Summary (2025-10-04)](../blob/main/strategy/Strategic-Insights-Summary-2025-10-04.md)
+
 ## Current Phase
 **Validation** — Insurance, three-population partnership outreach, QC baselines, disposal/recycling options.
 


### PR DESCRIPTION
## Summary
- add the 2025-10-04 Strategic Insights Summary covering multi-population, GTM, and insurance validation themes
- surface the summary from the wiki Home page Owner Brief section
- record the consolidated strategy decision in the decision log

## Testing
- not run (docs-only)


------
https://chatgpt.com/codex/tasks/task_e_68e1e03be5a0832c9bf39b833899405b